### PR TITLE
Implement Search & Suggestions - Data and Domain

### DIFF
--- a/lib/data/remote/dto/WorkspaceSearchRequestDto.dart
+++ b/lib/data/remote/dto/WorkspaceSearchRequestDto.dart
@@ -1,0 +1,34 @@
+class WorkspaceSearchRequestDto {
+  final String? keyword;
+  final double? minPrice;
+  final double? maxPrice;
+  final double? minRating;
+  final double? latitude;
+  final double? longitude;
+  final String? location;
+  final List<String>? services;
+
+  WorkspaceSearchRequestDto({
+    this.keyword,
+    this.minPrice,
+    this.maxPrice,
+    this.minRating,
+    this.latitude,
+    this.longitude,
+    this.location,
+    this.services,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      "keyword": keyword,
+      "minPrice": minPrice,
+      "maxPrice": maxPrice,
+      "minRating": minRating,
+      "latitude": latitude,
+      "longitude": longitude,
+      "location": location,
+      "services": services,
+    };
+  }
+}

--- a/lib/data/remote/search_api_service.dart
+++ b/lib/data/remote/search_api_service.dart
@@ -1,0 +1,14 @@
+import 'dto/WorkspaceResponse.dart';
+import 'dto/WorkspaceSearchRequestDto.dart';
+
+abstract class SearchApiService {
+  Future<List<WorkspaceResponse>> searchWorkspaces({
+    required WorkspaceSearchRequestDto request,
+    int page = 0,
+    int size = 10,
+  });
+
+  Future<List<String>> getSuggestions({
+    required String keyword,
+  });
+}

--- a/lib/data/remote/search_api_service_impl.dart
+++ b/lib/data/remote/search_api_service_impl.dart
@@ -1,0 +1,78 @@
+import 'package:dio/dio.dart';
+import 'package:share_space/data/remote/search_api_service.dart';
+
+import 'dto/WorkspaceResponse.dart';
+import 'dto/WorkspaceSearchRequestDto.dart';
+import 'error_handler.dart';
+
+class SearchApiServiceImpl extends SearchApiService {
+  final Dio _dio;
+
+  SearchApiServiceImpl(this._dio);
+
+  @override
+  Future<List<WorkspaceResponse>> searchWorkspaces({
+    required WorkspaceSearchRequestDto request,
+    int page = 0,
+    int size = 10,
+  }) async {
+    try {
+      final response = await _dio.post(
+        '/workspace/search',
+        data: request.toJson(),
+        queryParameters: {'page': page, 'size': size},
+      );
+
+      final data = response.data;
+      if (data == null) {
+        throw Exception('No response data');
+      }
+
+      if (data['success'] != true) {
+        throw Exception(data['message'] ?? 'Failed to fetch search results');
+      }
+
+      final content = data['data']?['content'];
+      if (content is List) {
+        return WorkspaceResponse.listFromJson(content);
+      }
+
+      return [];
+    } on DioException catch (e) {
+      throw handleError(e);
+    } catch (e) {
+      throw Exception('Unexpected error: $e');
+    }
+  }
+
+  @override
+  Future<List<String>> getSuggestions({required String keyword}) async {
+    try {
+      final response = await _dio.get(
+        '/workspace/suggestions',
+        queryParameters: {'keyword': keyword},
+        options: Options(extra: {'forceRefresh': true}),
+      );
+
+      final data = response.data;
+      if (data == null) {
+        throw Exception('No response data');
+      }
+
+      if (data['success'] != true) {
+        throw Exception(data['message'] ?? 'Failed to fetch suggestions');
+      }
+
+      final list = data['data'];
+      if (list is List) {
+        return List<String>.from(list);
+      }
+
+      return [];
+    } on DioException catch (e) {
+      throw handleError(e);
+    } catch (e) {
+      throw Exception('Unexpected error: $e');
+    }
+  }
+}

--- a/lib/data/repository/search_repository_impl.dart
+++ b/lib/data/repository/search_repository_impl.dart
@@ -1,0 +1,46 @@
+import 'package:share_space/data/mapper/workspace_mapper.dart';
+
+import '../../domain/entity/search.dart';
+import '../../domain/entity/workspace.dart';
+import '../../domain/repository/search_repository.dart';
+import '../remote/dto/WorkspaceSearchRequestDto.dart';
+import '../remote/search_api_service.dart';
+
+class SearchRepositoryImpl implements SearchRepository {
+  final SearchApiService _apiService;
+
+  SearchRepositoryImpl(this._apiService);
+
+  @override
+  Future<List<Workspace>> searchWorkspaces({
+    required SearchRequest request,
+  }) async {
+    try {
+      final dtoRequest = WorkspaceSearchRequestDto(
+        keyword: request.keyword,
+        minPrice: request.minPrice,
+        maxPrice: request.maxPrice,
+        minRating: request.rating,
+        services: request.services,
+        latitude: request.latitude,
+        longitude: request.longitude,
+        location: request.location,
+      );
+
+      final response = await _apiService.searchWorkspaces(request: dtoRequest);
+
+      return response.map((dto) => dto.mapToEntity()).toList();
+    } catch (e) {
+      throw Exception('Failed to search workspaces: $e');
+    }
+  }
+
+  @override
+  Future<List<String>> getSuggestions({required String keyword}) async {
+    try {
+      return await _apiService.getSuggestions(keyword: keyword);
+    } catch (e) {
+      throw Exception('Failed to fetch suggestions: $e');
+    }
+  }
+}

--- a/lib/di/injection.dart
+++ b/lib/di/injection.dart
@@ -28,24 +28,29 @@ import 'package:share_space/domain/usecase/workspace/get_featured.dart';
 import 'package:share_space/domain/usecase/workspace/get_near_to_you.dart';
 import 'package:share_space/domain/usecase/workspace/get_popular.dart';
 import 'package:share_space/domain/usecase/workspace/get_top_rated.dart';
+import 'package:share_space/domain/usecase/workspace/remove_saved_workspace.dart';
+import 'package:share_space/domain/usecase/workspace/save_workspace.dart';
 import 'package:share_space/presentation/screen/booking_history/state/booking_history_cubit.dart';
 import 'package:share_space/presentation/screen/home/state/home_cubit.dart';
 import 'package:share_space/presentation/screen/login/state/login_cubit.dart';
 
-import 'package:share_space/domain/usecase/workspace/save_workspace.dart';
-import 'package:share_space/domain/usecase/workspace/remove_saved_workspace.dart';
-
 import '../data/remote/auth_api_service_impl.dart';
 import '../data/remote/booking_api_service.dart';
 import '../data/remote/dio_client.dart';
+import '../data/remote/search_api_service.dart';
+import '../data/remote/search_api_service_impl.dart';
 import '../data/remote/workspace_api_service.dart';
 import '../data/remote/workspace_api_service_impl.dart';
 import '../data/repository/booking_repository_impl.dart';
+import '../data/repository/search_repository_impl.dart';
 import '../domain/repository/booking_repository.dart';
+import '../domain/repository/search_repository.dart';
 import '../domain/usecase/authentication/create_account_usecase.dart';
 import '../domain/usecase/authentication/is_loggedIn_usecase.dart';
 import '../domain/usecase/authentication/logout_usecase.dart';
 import '../domain/usecase/booking/cancel_booking.dart';
+import '../domain/usecase/search/get_suggestions.dart';
+import '../domain/usecase/search/search_workspaces.dart';
 import '../presentation/screen/booking/state/booking_cubit.dart';
 import '../presentation/screen/my_account/cubit/my_account_cubit.dart';
 
@@ -71,18 +76,16 @@ void setupDependencies() {
   getIt.registerLazySingleton(() => RemoveSavedWorkspaceUseCase(getIt()));
 
   getIt.registerLazySingleton<BookingApiService>(
-        () => BookingApiServiceImpl(getIt()),
+    () => BookingApiServiceImpl(getIt()),
   );
 
   getIt.registerLazySingleton<BookingRepository>(
-        () => BookingRepositoryImpl(getIt()),
+    () => BookingRepositoryImpl(getIt()),
   );
 
   getIt.registerLazySingleton<UserRepository>(
-        () => UserRepositoryImpl(getIt(),getIt()),
+    () => UserRepositoryImpl(getIt(), getIt()),
   );
-
-
 
   getIt.registerLazySingleton(() => GetBestUseCase(getIt()));
   getIt.registerLazySingleton(() => GetBestPriceUseCase(getIt()));
@@ -96,7 +99,6 @@ void setupDependencies() {
   getIt.registerLazySingleton(() => GetBookingHistoryUseCase(getIt()));
   getIt.registerLazySingleton(() => BookRoomUseCase(getIt()));
   getIt.registerLazySingleton(() => CancelBookingUseCase(getIt()));
-
 
   getIt.registerFactory(
     () => HomeCubit(
@@ -120,11 +122,9 @@ void setupDependencies() {
   getIt.registerLazySingleton<AuthApiService>(
     () => AuthApiServiceImpl(getIt(), getIt()),
   );
-  getIt.registerLazySingleton<LocationService>(
-        () => LocationServiceImpl(),
-  );
+  getIt.registerLazySingleton<LocationService>(() => LocationServiceImpl());
   getIt.registerLazySingleton<UserApiService>(
-        () => UserApiServiceImpl(getIt()),
+    () => UserApiServiceImpl(getIt()),
   );
 
   getIt.registerLazySingleton(() => LoginUseCase(getIt()));
@@ -145,13 +145,26 @@ void setupDependencies() {
   );
 
   getIt.registerLazySingleton<LogoutUseCase>(
-        () => LogoutUseCase(getIt<AuthenticationRepository>()),
+    () => LogoutUseCase(getIt<AuthenticationRepository>()),
   );
 
   getIt.registerFactory<MyAccountCubit>(
-        () => MyAccountCubit(
-      getIt<GetUserDetailsUseCase>(),
-      getIt<LogoutUseCase>(),
-    ),
+    () =>
+        MyAccountCubit(getIt<GetUserDetailsUseCase>(), getIt<LogoutUseCase>()),
+  );
+
+  getIt.registerLazySingleton<SearchApiService>(
+    () => SearchApiServiceImpl(getIt<Dio>()),
+  );
+
+  getIt.registerLazySingleton<SearchRepository>(
+    () => SearchRepositoryImpl(getIt<SearchApiService>()),
+  );
+
+  getIt.registerLazySingleton(
+    () => SearchWorkspacesUseCase(getIt<SearchRepository>()),
+  );
+  getIt.registerLazySingleton(
+    () => GetSuggestionsUseCase(getIt<SearchRepository>()),
   );
 }

--- a/lib/domain/entity/search.dart
+++ b/lib/domain/entity/search.dart
@@ -1,0 +1,21 @@
+class SearchRequest {
+  final String? keyword;
+  final double? minPrice;
+  final double? maxPrice;
+  final double? rating;
+  final List<String>? services;
+  final double? latitude;
+  final double? longitude;
+  final String? location;
+
+  SearchRequest({
+    this.keyword,
+    this.minPrice,
+    this.maxPrice,
+    this.rating,
+    this.services,
+    this.latitude,
+    this.longitude,
+    this.location
+  });
+}

--- a/lib/domain/repository/search_repository.dart
+++ b/lib/domain/repository/search_repository.dart
@@ -1,0 +1,10 @@
+import '../entity/search.dart';
+import '../entity/workspace.dart';
+
+abstract class SearchRepository {
+  Future<List<Workspace>> searchWorkspaces({
+    required SearchRequest request,
+  });
+
+  Future<List<String>> getSuggestions({required String keyword});
+}

--- a/lib/domain/usecase/search/get_suggestions.dart
+++ b/lib/domain/usecase/search/get_suggestions.dart
@@ -1,0 +1,11 @@
+import '../../repository/search_repository.dart';
+
+class GetSuggestionsUseCase {
+  final SearchRepository _repository;
+
+  GetSuggestionsUseCase(this._repository);
+
+  Future<List<String>> execute(String keyword) async {
+    return await _repository.getSuggestions(keyword: keyword);
+  }
+}

--- a/lib/domain/usecase/search/search_workspaces.dart
+++ b/lib/domain/usecase/search/search_workspaces.dart
@@ -1,0 +1,13 @@
+import '../../entity/search.dart';
+import '../../entity/workspace.dart';
+import '../../repository/search_repository.dart';
+
+class SearchWorkspacesUseCase {
+  final SearchRepository _repository;
+
+  SearchWorkspacesUseCase(this._repository);
+
+  Future<List<Workspace>> execute(SearchRequest request) async {
+    return await _repository.searchWorkspaces(request: request);
+  }
+}

--- a/lib/presentation/screen/room_details/room_details_screen.dart
+++ b/lib/presentation/screen/room_details/room_details_screen.dart
@@ -75,7 +75,7 @@ class RoomDetailsScreen extends StatelessWidget {
                   state: state,
                   roomId: resolvedRoomId,
                 ),
-              bottomNavigationBar: RoomBookingBar(price: state.price),
+              bottomNavigationBar: RoomBookingBar(price: state.price, roomId: '',),
             );
           }
 

--- a/lib/presentation/screen/room_details/room_details_screen.dart
+++ b/lib/presentation/screen/room_details/room_details_screen.dart
@@ -75,7 +75,7 @@ class RoomDetailsScreen extends StatelessWidget {
                   state: state,
                   roomId: resolvedRoomId,
                 ),
-              bottomNavigationBar: RoomBookingBar(price: state.price, roomId: '',),
+              bottomNavigationBar: RoomBookingBar(price: state.price, roomId: resolvedRoomId),
             );
           }
 


### PR DESCRIPTION
This PR adds a complete search (Data and Domain ) Implementation .

What’s Added : 
1. Domain Layer

✔ Entities

      -  SearchRequest

✔ Use Cases

       -  SearchWorkspacesUseCase

        - GetSuggestionsUseCase

3. Data Layer
✔ API Service Implementation

      - SearchApiServiceImpl:

            - Added searchWorkspaces()

            - Added getSuggestions()

           - Improved null checks, error handling, and JSON parsing

✔ Repository Implementation

           - Connected use cases with the API service

            - Ensures domain returns clean Workspace entities, not raw JSON


<img width="258" height="532" alt="image" src="https://github.com/user-attachments/assets/cf3add85-0107-4b9d-bcc0-36a8294a9003" />

<img width="258" height="532" alt="image" src="https://github.com/user-attachments/assets/38ce9df4-abf5-4c8b-a1c7-40e5de15f563" />
